### PR TITLE
fix(cmd_127 S127-1): update teraflow.yml to assignments format

### DIFF
--- a/.github/teraflow.yml
+++ b/.github/teraflow.yml
@@ -12,10 +12,29 @@ confirmation:
 ai:
   default_provider: openai
 
+assignments:
+  requirements:
+    provider: openai
+    model: gpt-4o-mini
+  review:
+    provider: openai
+    model: gpt-4o-mini
+  implement:
+    provider: openai
+    model: gpt-4o-mini
+  ci-fix:
+    provider: openai
+    model: gpt-4o-mini
+  conflict:
+    provider: openai
+    model: gpt-4o-mini
+  incident:
+    provider: openai
+    model: gpt-4o-mini
+  maintenance:
+    provider: openai
+    model: gpt-4o-mini
+
 harness:
   score_threshold: 70
   auto_issue: false
-
-agent:
-  provider: openai-codex
-  model: gpt-5.3-codex


### PR DESCRIPTION
## Summary
- agent.provider/model（旧形式）を削除
- assignments 形式で全エージェントタイプに openai/gpt-4o-mini を設定
- openai-codex（無効なprovider名）を openai に修正

🤖 Generated with cmd_127 S127-1