### PR TITLE
fix(cmd_144): updateDiscussionComment for ACK update + debug stderr

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -203,7 +203,7 @@ jobs:
             }' \
             -f id="${{ github.event.discussion.node_id }}" \
             -f body="📝 内容を確認中です..." \
-            $REPLY_ARGS 2>/dev/null || echo '{}')
+            $REPLY_ARGS || echo '{}')
 
           ACK_ID=$(echo "$ACK_RESULT" | python3 -c \
             "import json,sys; print(json.load(sys.stdin).get('data',{}).get('addDiscussionComment',{}).get('comment',{}).get('id',''))" \


### PR DESCRIPTION
## Bugfix
- Update ACKステップのmutationをaddDiscussionComment→updateDiscussionCommentに修正
  - エラー: \"Parent comment is already in a thread, cannot reply to it\" を解消
  - commentId: steps.ack.outputs.comment_id を使用
- ACK投稿の2>/dev/nullを削除（エラーをログで確認可能に）

🤖 Generated with cmd_144 bugfix