### PR TITLE
fix(cmd_144): prevent github-actions[bot] loop + fix setup-go yaml

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   req-agent:
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
     permissions:
       contents: write
       discussions: write
@@ -137,11 +138,7 @@ jobs:
 
 
       - uses: actions/setup-go@v5
-
-
         with:
-
-
           go-version: stable
           cache: false
 


### PR DESCRIPTION
## Bugfix
- jobs.req-agent に \ 追加
  - ACKコメント投稿後のbot自身による無限ループを防止
  - 4回連続failureの根本原因を解消
- setup-go ステップの余分な空行を削除（YAML構文の正規化）

🤖 Generated with cmd_144 workflow fix