### PR TITLE
fix(cmd219/T8): replace invalid !((expr)) in Post response step

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -1354,7 +1354,7 @@ jobs:
           > *teraflow discovery agent guard*"
 
       - name: Post response
-        if: steps.check.outputs.has_key == 'true' && !((steps.mode.outputs.mode == 'confirm' || steps.mode.outputs.mode == 'discovery-confirm') && steps.guard_docgen.outputs.skip == 'true')
+        if: steps.check.outputs.has_key == 'true' && (steps.guard_docgen.outputs.skip != 'true' || (steps.mode.outputs.mode != 'confirm' && steps.mode.outputs.mode != 'discovery-confirm'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## cmd_219 T8: Post response step expression fix (teraflow-check direct patch)

Same fix as teraflow#220 applied directly to deployed workflow.

- `!((A || B) && C)` → `(guard != skip) || (mode != confirm AND mode != discovery-confirm)`
- Fixes "workflow file issue" that prevents ALL workflow runs since T3 deployment
- Discussion-triggered runs were not starting due to this expression bug

Generated with cmd_219/T8