### PR TITLE
bisect: add Post confirmed-empty warning step only [cmd219]

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -1024,6 +1024,25 @@ jobs:
           fi
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
+      - name: Post confirmed-empty warning
+        if: steps.check.outputs.has_key == 'true' && steps.mode.outputs.skip == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation($id: ID!, $body: String!) {
+              addDiscussionComment(input: {discussionId: $id, body: $body}) {
+                comment { id }
+              }
+            }' \
+            -f id="${{ github.event.discussion.node_id }}" \
+            -f body="## ⚠️ 要件確定を保留しました
+
+          confirmed が 0 件のため、CoDD 文書生成をスキップしました。
+          まず質問への回答を追加し、confirmed を蓄積してから再度「要求確定」を実行してください。
+
+          > *teraflow discovery agent guard*"
+
       - name: Post response
         if: steps.check.outputs.has_key == 'true'
         env:


### PR DESCRIPTION
Bisect test: adding only the 'Post confirmed-empty warning' step to isolate what breaks discussion event triggering in 1527-line version.