### PR TITLE
fix: optimize Python functions for 32KB limit [cmd219]

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -790,22 +790,8 @@ jobs:
               if not user_text:
                   return parsed
               normalized = user_text.strip()
-              normalized = normalized.translate(str.maketrans({
-                  "０": "0", "１": "1", "２": "2", "３": "3", "４": "4",
-                  "５": "5", "６": "6", "７": "7", "８": "8", "９": "9",
-                  "Ａ": "A", "Ｂ": "B", "Ｃ": "C", "Ｄ": "D", "Ｅ": "E",
-                  "Ｆ": "F", "Ｇ": "G", "Ｈ": "H", "Ｉ": "I", "Ｊ": "J",
-                  "Ｋ": "K", "Ｌ": "L", "Ｍ": "M", "Ｎ": "N", "Ｏ": "O",
-                  "Ｐ": "P", "Ｑ": "Q", "Ｒ": "R", "Ｓ": "S", "Ｔ": "T",
-                  "Ｕ": "U", "Ｖ": "V", "Ｗ": "W", "Ｘ": "X", "Ｙ": "Y",
-                  "Ｚ": "Z", "ａ": "a", "ｂ": "b", "ｃ": "c", "ｄ": "d",
-                  "ｅ": "e", "ｆ": "f", "ｇ": "g", "ｈ": "h", "ｉ": "i",
-                  "ｊ": "j", "ｋ": "k", "ｌ": "l", "ｍ": "m", "ｎ": "n",
-                  "ｏ": "o", "ｐ": "p", "ｑ": "q", "ｒ": "r", "ｓ": "s",
-                  "ｔ": "t", "ｕ": "u", "ｖ": "v", "ｗ": "w", "ｘ": "x",
-                  "ｙ": "y", "ｚ": "z", "，": ",", "、": ",", "／": "/",
-                  "－": "-", "．": ".",
-              }))
+              import unicodedata
+              normalized = unicodedata.normalize("NFKC", normalized).replace("、", ",")
               for m in re.finditer(r"(\d+)\s*[\.\-:\)]?\s*([a-z](?:\s*[,/]\s*[a-z])*)", normalized.lower()):
                   q_num = int(m.group(1))
                   letters = re.findall(r"[a-z]", m.group(2))


### PR DESCRIPTION
Root cause found: GitHub has ~32KB limit on step run blocks. The Python functions block pushed the discovery step from 18KB to 33KB. Fix: replace str.maketrans({...}) with unicodedata.normalize to save ~1KB and stay under limit.