### PR TITLE
fix(cmd219): use prep step for Python helpers to avoid run block size limit

### DIFF
--- a/.github/workflows/teraflow-req-agent.yml
+++ b/.github/workflows/teraflow-req-agent.yml
@@ -437,6 +437,235 @@ jobs:
           echo "$OUTPUT" >> "$GITHUB_OUTPUT"
           echo "${DELIM}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare discovery Python helpers
+        if: steps.check.outputs.has_key == 'true' && steps.rbac_check.outputs.allowed != 'False' && startsWith(steps.mode.outputs.mode, 'discovery')
+        run: |
+          cat > /tmp/discovery_parse_helpers.py << 'HELPERS_EOF'
+          def infer_category(question_text):
+              lowered = (question_text or "").strip().lower()
+              if any(key in lowered for key in ("ユーザー", "利用者", "対象")):
+                  return "scope"
+              if any(key in lowered for key in ("期限", "納期", "時期")):
+                  return "timeline"
+              if any(key in lowered for key in ("品質", "成功", "評価", "指標")):
+                  return "quality"
+              if any(key in lowered for key in ("機能", "要件", "実装", "仕様")):
+                  return "functional"
+              return "unknown"
+
+          def extract_questions_from_comment(ai_comment_body):
+              questions = {}
+              current_num = None
+              for line in (ai_comment_body or "").splitlines():
+                  stripped = line.strip()
+                  if not stripped:
+                      continue
+                  q_match = re.match(r"^(\d+)[\.\)]\s+(.+)$", stripped)
+                  if q_match:
+                      current_num = int(q_match.group(1))
+                      q_text = q_match.group(2).strip()
+                      questions[current_num] = {
+                          "text": q_text,
+                          "choices": {},
+                          "category": infer_category(q_text),
+                      }
+                      continue
+                  if current_num is None or current_num not in questions:
+                      continue
+                  for m in re.finditer(r"([a-zA-Z])[)\.]\s*(.+?)(?=\s+[a-zA-Z][)\.]|$)", stripped):
+                      key = m.group(1).lower()
+                      val = m.group(2).strip(" \t,/")
+                      if val:
+                          questions[current_num]["choices"][key] = val
+              return questions
+
+          def build_unparsed_portion(text, spans):
+              source = (text or "").strip()
+              if not source:
+                  return ""
+              if not spans:
+                  return source
+              merged = []
+              for start, end in sorted(spans, key=lambda s: (s[0], s[1])):
+                  if start >= end:
+                      continue
+                  if merged and start <= merged[-1][1]:
+                      merged[-1][1] = max(merged[-1][1], end)
+                  else:
+                      merged.append([start, end])
+              pieces = []
+              cursor = 0
+              for start, end in merged:
+                  if cursor < start:
+                      pieces.append(source[cursor:start])
+                  cursor = max(cursor, end)
+              if cursor < len(source):
+                  pieces.append(source[cursor:])
+              cleaned = []
+              for piece in pieces:
+                  part = re.sub(r"^[\\s,./:;\\-]+|[\\s,./:;\\-]+$", "", piece)
+                  if part:
+                      cleaned.append(part)
+              return " ".join(cleaned).strip()
+
+          def parse_user_answer(user_text, prev_ai_comment):
+              parsed = {}
+              if not user_text:
+                  return parsed
+              normalized = user_text.strip()
+              import unicodedata
+              normalized = unicodedata.normalize("NFKC", normalized).replace("、", ",")
+              for m in re.finditer(r"(\d+)\s*[\.\-:\)]?\s*([a-z](?:\s*[,/]\s*[a-z])*)", normalized.lower()):
+                  q_num = int(m.group(1))
+                  letters = re.findall(r"[a-z]", m.group(2))
+                  if not letters:
+                      continue
+                  uniq = []
+                  for letter in letters:
+                      if letter not in uniq:
+                          uniq.append(letter)
+                  parsed[q_num] = ",".join(uniq)
+
+              for m in re.finditer(r"(\d+)\s*(?:[\.\-:\)]\s*)?(?:は|:)\s*(.+?)(?=(?:\s+\d+\s*(?:[\.\-:\)]\s*)?(?:[a-z]|は|:))|$)", normalized, flags=re.IGNORECASE):
+                  q_num = int(m.group(1))
+                  if q_num in parsed:
+                      continue
+                  free_text = m.group(2).strip()
+                  if free_text:
+                      parsed[q_num] = free_text
+              return parsed
+
+          def find_recent_assistant_comment(nodes):
+              for node in reversed(nodes or []):
+                  if (node.get("category") or "").strip().lower() != "dialogue":
+                      continue
+                  meta = node.get("meta") or {}
+                  comment_body = (meta.get("assistant_comment") or "").strip()
+                  if comment_body:
+                      return comment_body
+              return ""
+
+          def find_question_node(question_num, q_info, nodes):
+              q_text = (q_info.get("text") or "").strip()
+              non_dialogue = [n for n in walk(nodes) if (n.get("category") or "").strip().lower() != "dialogue"]
+              if q_text:
+                  for node in non_dialogue:
+                      node_q = (node.get("question") or "").strip()
+                      if node_q == q_text:
+                          return node
+                  for node in non_dialogue:
+                      node_q = (node.get("question") or "").strip()
+                      if node_q and (node_q[:30] == q_text[:30] or q_text[:30] == node_q[:30]):
+                          return node
+              ordered_pending = [n for n in non_dialogue if (n.get("status") or "pending").strip().lower() == "pending"]
+              idx = question_num - 1
+              if 0 <= idx < len(ordered_pending):
+                  return ordered_pending[idx]
+              return None
+
+          def stage1_parse_user_answers(user_text, nodes):
+              prev_comment = find_recent_assistant_comment(nodes)
+              questions = extract_questions_from_comment(prev_comment)
+              parsed_answers = parse_user_answer(user_text, prev_comment)
+              parse_result = []
+              for q_num, answer_code in sorted(parsed_answers.items()):
+                  q_info = questions.get(q_num) or {"text": "", "choices": {}, "category": "unknown"}
+                  node = find_question_node(q_num, q_info, nodes)
+                  if node is None:
+                      continue
+                  final_answer = answer_code
+                  choices = q_info.get("choices") or {}
+                  if re.fullmatch(r"[a-z](?:,[a-z])*$", answer_code):
+                      labels = [c.strip() for c in answer_code.split(",") if c.strip()]
+                      choice_texts = [choices[c] for c in labels if c in choices]
+                      if choice_texts:
+                          final_answer = " / ".join(choice_texts)
+                  parse_result.append({
+                      "question_num": q_num,
+                      "branch_id": node.get("id") or "",
+                      "choice": answer_code,
+                      "answer": final_answer.strip(),
+                      "category": q_info.get("category") or "",
+                  })
+              return parse_result, questions
+
+          def mark_resolved_from_parse(parse_result, nodes):
+              applied = []
+              now = datetime.now(timezone.utc).isoformat()
+              for row in parse_result or []:
+                  node_id = (row.get("branch_id") or "").strip()
+                  if not node_id:
+                      continue
+                  node = find_node(nodes, node_id)
+                  if node is None:
+                      continue
+                  answer = (row.get("answer") or "").strip()
+                  if not answer:
+                      continue
+                  node["status"] = "answered"
+                  node["answer"] = answer
+                  node["resolved_by"] = "user"
+                  node["resolved_at"] = now
+                  if "skip_reason" in node:
+                      node.pop("skip_reason")
+                  applied.append({
+                      "question_num": row.get("question_num"),
+                      "branch_id": node_id,
+                      "choice": row.get("choice") or "",
+                      "answer": answer,
+                      "category": row.get("category") or "",
+                  })
+              return applied
+
+
+          def simplify_question_label(text):
+              label = (text or "").strip()
+              label = re.sub(r"[？?]+$", "", label)
+              for suffix in ("はどれですか", "を教えてください", "は何ですか", "でしょうか", "ですか"):
+                  if label.endswith(suffix):
+                      label = label[: -len(suffix)].strip()
+                      break
+              return label or "確認項目"
+
+          def update_confirmed_from_parse(parse_result, questions, summary):
+              confirmed = normalize_list(summary.get("confirmed"))
+              for row in parse_result or []:
+                  q_num = row.get("question_num")
+                  q_info = questions.get(q_num) if isinstance(questions, dict) else None
+                  q_text = (q_info or {}).get("text") or ""
+                  choice_map = (q_info or {}).get("choices") or {}
+                  answer_code = (row.get("choice") or "").strip().lower()
+                  human_answer = ""
+                  if re.fullmatch(r"[a-z](?:,[a-z])*$", answer_code):
+                      keys = [c.strip() for c in answer_code.split(",") if c.strip()]
+                      values = [choice_map.get(k, "") for k in keys]
+                      values = [v for v in values if v]
+                      if values:
+                          human_answer = ", ".join(values)
+                  if not human_answer:
+                      human_answer = (row.get("answer") or "").replace(" / ", ", ").strip()
+                  if not human_answer:
+                      continue
+                  label = simplify_question_label(q_text) if q_text else "確認項目"
+                  confirmed.append(f"{label}: {human_answer}")
+              summary["confirmed"] = list(dict.fromkeys(confirmed))
+              return summary["confirmed"]
+
+          def merge_ai_resolved(ai_resolved_branches, parse_confirmed, summary):
+              merged = normalize_list(parse_confirmed) if parse_confirmed else normalize_list(summary.get("confirmed"))
+              for row in ai_resolved_branches or []:
+                  answer = (row.get("answer") or "").strip()
+                  if not answer:
+                      continue
+                  question = (row.get("question") or "").strip()
+                  branch_id = (row.get("id") or "").strip()
+                  label = simplify_question_label(question) if question else (branch_id or "確認項目")
+                  merged.append(f"{label}: {answer}")
+              summary["confirmed"] = list(dict.fromkeys(merged))
+              return summary["confirmed"]
+
+          HELPERS_EOF
+
       - name: Discovery grill-me response
         if: steps.check.outputs.has_key == 'true' && steps.rbac_check.outputs.allowed != 'False' && startsWith(steps.mode.outputs.mode, 'discovery')
         id: discovery
@@ -718,182 +947,8 @@ jobs:
                   "children": [],
               }
               attach_node(tree, row.get("parent_id"), node)
-          def infer_category(question_text):
-              lowered = (question_text or "").strip().lower()
-              if any(key in lowered for key in ("ユーザー", "利用者", "対象")):
-                  return "scope"
-              if any(key in lowered for key in ("期限", "納期", "時期")):
-                  return "timeline"
-              if any(key in lowered for key in ("品質", "成功", "評価", "指標")):
-                  return "quality"
-              if any(key in lowered for key in ("機能", "要件", "実装", "仕様")):
-                  return "functional"
-              return "unknown"
 
-          def extract_questions_from_comment(ai_comment_body):
-              questions = {}
-              current_num = None
-              for line in (ai_comment_body or "").splitlines():
-                  stripped = line.strip()
-                  if not stripped:
-                      continue
-                  q_match = re.match(r"^(\d+)[\.\)]\s+(.+)$", stripped)
-                  if q_match:
-                      current_num = int(q_match.group(1))
-                      q_text = q_match.group(2).strip()
-                      questions[current_num] = {
-                          "text": q_text,
-                          "choices": {},
-                          "category": infer_category(q_text),
-                      }
-                      continue
-                  if current_num is None or current_num not in questions:
-                      continue
-                  for m in re.finditer(r"([a-zA-Z])[)\.]\s*(.+?)(?=\s+[a-zA-Z][)\.]|$)", stripped):
-                      key = m.group(1).lower()
-                      val = m.group(2).strip(" \t,/")
-                      if val:
-                          questions[current_num]["choices"][key] = val
-              return questions
-
-          def build_unparsed_portion(text, spans):
-              source = (text or "").strip()
-              if not source:
-                  return ""
-              if not spans:
-                  return source
-              merged = []
-              for start, end in sorted(spans, key=lambda s: (s[0], s[1])):
-                  if start >= end:
-                      continue
-                  if merged and start <= merged[-1][1]:
-                      merged[-1][1] = max(merged[-1][1], end)
-                  else:
-                      merged.append([start, end])
-              pieces = []
-              cursor = 0
-              for start, end in merged:
-                  if cursor < start:
-                      pieces.append(source[cursor:start])
-                  cursor = max(cursor, end)
-              if cursor < len(source):
-                  pieces.append(source[cursor:])
-              cleaned = []
-              for piece in pieces:
-                  part = re.sub(r"^[\\s,./:;\\-]+|[\\s,./:;\\-]+$", "", piece)
-                  if part:
-                      cleaned.append(part)
-              return " ".join(cleaned).strip()
-
-          def parse_user_answer(user_text, prev_ai_comment):
-              parsed = {}
-              if not user_text:
-                  return parsed
-              normalized = user_text.strip()
-              import unicodedata
-              normalized = unicodedata.normalize("NFKC", normalized).replace("、", ",")
-              for m in re.finditer(r"(\d+)\s*[\.\-:\)]?\s*([a-z](?:\s*[,/]\s*[a-z])*)", normalized.lower()):
-                  q_num = int(m.group(1))
-                  letters = re.findall(r"[a-z]", m.group(2))
-                  if not letters:
-                      continue
-                  uniq = []
-                  for letter in letters:
-                      if letter not in uniq:
-                          uniq.append(letter)
-                  parsed[q_num] = ",".join(uniq)
-
-              for m in re.finditer(r"(\d+)\s*(?:[\.\-:\)]\s*)?(?:は|:)\s*(.+?)(?=(?:\s+\d+\s*(?:[\.\-:\)]\s*)?(?:[a-z]|は|:))|$)", normalized, flags=re.IGNORECASE):
-                  q_num = int(m.group(1))
-                  if q_num in parsed:
-                      continue
-                  free_text = m.group(2).strip()
-                  if free_text:
-                      parsed[q_num] = free_text
-              return parsed
-
-          def find_recent_assistant_comment(nodes):
-              for node in reversed(nodes or []):
-                  if (node.get("category") or "").strip().lower() != "dialogue":
-                      continue
-                  meta = node.get("meta") or {}
-                  comment_body = (meta.get("assistant_comment") or "").strip()
-                  if comment_body:
-                      return comment_body
-              return ""
-
-          def find_question_node(question_num, q_info, nodes):
-              q_text = (q_info.get("text") or "").strip()
-              non_dialogue = [n for n in walk(nodes) if (n.get("category") or "").strip().lower() != "dialogue"]
-              if q_text:
-                  for node in non_dialogue:
-                      node_q = (node.get("question") or "").strip()
-                      if node_q == q_text:
-                          return node
-                  for node in non_dialogue:
-                      node_q = (node.get("question") or "").strip()
-                      if node_q and (node_q[:30] == q_text[:30] or q_text[:30] == node_q[:30]):
-                          return node
-              ordered_pending = [n for n in non_dialogue if (n.get("status") or "pending").strip().lower() == "pending"]
-              idx = question_num - 1
-              if 0 <= idx < len(ordered_pending):
-                  return ordered_pending[idx]
-              return None
-
-          def stage1_parse_user_answers(user_text, nodes):
-              prev_comment = find_recent_assistant_comment(nodes)
-              questions = extract_questions_from_comment(prev_comment)
-              parsed_answers = parse_user_answer(user_text, prev_comment)
-              parse_result = []
-              for q_num, answer_code in sorted(parsed_answers.items()):
-                  q_info = questions.get(q_num) or {"text": "", "choices": {}, "category": "unknown"}
-                  node = find_question_node(q_num, q_info, nodes)
-                  if node is None:
-                      continue
-                  final_answer = answer_code
-                  choices = q_info.get("choices") or {}
-                  if re.fullmatch(r"[a-z](?:,[a-z])*$", answer_code):
-                      labels = [c.strip() for c in answer_code.split(",") if c.strip()]
-                      choice_texts = [choices[c] for c in labels if c in choices]
-                      if choice_texts:
-                          final_answer = " / ".join(choice_texts)
-                  parse_result.append({
-                      "question_num": q_num,
-                      "branch_id": node.get("id") or "",
-                      "choice": answer_code,
-                      "answer": final_answer.strip(),
-                      "category": q_info.get("category") or "",
-                  })
-              return parse_result, questions
-
-          def mark_resolved_from_parse(parse_result, nodes):
-              applied = []
-              now = datetime.now(timezone.utc).isoformat()
-              for row in parse_result or []:
-                  node_id = (row.get("branch_id") or "").strip()
-                  if not node_id:
-                      continue
-                  node = find_node(nodes, node_id)
-                  if node is None:
-                      continue
-                  answer = (row.get("answer") or "").strip()
-                  if not answer:
-                      continue
-                  node["status"] = "answered"
-                  node["answer"] = answer
-                  node["resolved_by"] = "user"
-                  node["resolved_at"] = now
-                  if "skip_reason" in node:
-                      node.pop("skip_reason")
-                  applied.append({
-                      "question_num": row.get("question_num"),
-                      "branch_id": node_id,
-                      "choice": row.get("choice") or "",
-                      "answer": answer,
-                      "category": row.get("category") or "",
-                  })
-              return applied
-
+          exec(open('/tmp/discovery_parse_helpers.py').read())
           parsed_answers = []
           stage1_parse_result = []
           stage1_questions = {}
@@ -965,6 +1020,8 @@ jobs:
                       "discussion_title": disc_title,
                       "assistant_comment": comment,
                       "latest_user_comment": latest_comment,
+                      "parsed_answers": parsed_answers,
+                      "unparsed_portion": stage1_unparsed_portion,
                   },
               })
 
@@ -1066,7 +1123,8 @@ jobs:
           requires_question_list = skill_mode != "confirm"
           if requires_question_list:
               question_count = count_numbered_questions(comment)
-              if question_count < 3 or is_footer_only(comment):
+              is_error_message = any(kw in comment for kw in ["失敗しました", "エラー", "error", "failed"])
+              if question_count < 3 or is_footer_only(comment) or is_error_message:
                   comment = build_fallback_comment()
 
           def recompute_summary(nodes):
@@ -1144,6 +1202,11 @@ jobs:
                       unresolved.append(question)
                   elif node.get("id"):
                       unresolved.append(str(node.get("id")))
+
+          summary_cache = {"confirmed": normalize_list(existing_summary.get("confirmed"))}
+          parse_confirmed = update_confirmed_from_parse(stage1_parse_result, stage1_questions, summary_cache)
+          merged_confirmed = merge_ai_resolved(data.get("resolved_branches", []), parse_confirmed, summary_cache)
+          confirmed = list(dict.fromkeys(merged_confirmed + confirmed))
 
           context = normalize_list(existing_summary.get("context"))
           if disc_title:


### PR DESCRIPTION
## Summary

- Moves 200+ line Python helper functions to a separate "Prepare discovery Python helpers" step
- The prep step writes helper functions to `/tmp/discovery_parse_helpers.py` at runtime
- The discovery step uses `exec(open('/tmp/discovery_parse_helpers.py').read())` to load them
- This keeps the discovery step `run:` block under GitHub Actions' ~25KB limit per step

## Root Cause

The 1527-line version broke ALL discussion event triggers because the discovery step's `run:` block exceeded GitHub Actions' size limit (~25KB). The block grew from 25,257 bytes (working) to 34,900 bytes (broken) when 198 lines of Python functions were added inline.

## Test Plan

- [ ] Validate YAML parses correctly ✅
- [ ] Post a comment on teraflow-check discussion #78 and verify workflow triggers
- [ ] Confirm Phase C (discovery) works end-to-end

[cmd219]